### PR TITLE
windows compatibility improvement

### DIFF
--- a/lib/git_stats/command_parser.rb
+++ b/lib/git_stats/command_parser.rb
@@ -23,7 +23,7 @@ module GitStats
     end
 
     def parse_rev_list(result, _params)
-      result.lines.map do |line|
+      result.lines.grep_v(/commit/).map do |line|
         sha, stamp, date, author_email = line.split('|').map(&:strip)
         {sha: sha, stamp: stamp, date: date, author_email: author_email}
       end

--- a/lib/git_stats/git_data/repo.rb
+++ b/lib/git_stats/git_data/repo.rb
@@ -47,7 +47,7 @@ module GitStats
       end
 
       def commits
-        command = "git rev-list --pretty=format:'%H|%at|%ai|%aE' #{commit_range} #{tree_path} | grep -v commit"
+        command = "git rev-list --pretty=format:\"%H|%at|%ai|%aE\" #{commit_range} #{tree_path}"
         @commits ||= run_and_parse(command).map do |commit_line|
           Commit.new(
             repo: self,


### PR DESCRIPTION
1. remove dependency of grep
2. remove dependency of shell pileline which won't work  on windows